### PR TITLE
Add dev volume to persist Postgres and expose port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,12 @@ services:
 
   db:
     image: postgres:latest
+    ports:
+      - 5432:5432
     environment:
       - POSTGRES_PASSWORD=postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
 
   dev:
     image: ghcr.io/nationalarchives/tna-python-dev:preview
@@ -39,3 +43,6 @@ services:
       - .:/docs
     ports:
       - 65526:8000
+
+volumes:
+  pgdata:


### PR DESCRIPTION
#### Description of the change

- Adds a volume to persist Postgres data
- Exposes Postgres on a port for development purposes

#### Tickets

n/a

#### Dev checklist

- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Self code review
- [x] Requested code review