### PR TITLE
fix: clean up dockerfile to preserve build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,28 +7,6 @@ ENV NPM_BUILD_COMMAND=compile
 ARG BUILD_VERSION
 ENV BUILD_VERSION="$BUILD_VERSION"
 
-######################################################################
-# UID/GID configuration for cross-platform development
-#
-# This section is primarily needed for Linux users running Docker Engine, where
-# file permission issues can occur when mounting volumes. It sets the UID/GID
-# for the 'app' user in the container to match the host system, preventing
-# problems with file ownership.
-#
-# Docker Desktop and OrbStack users usually do not need to set these args, as
-# their Docker implementations handle permissions differently.
-#
-# For more info, see README.md
-######################################################################
-USER root
-ARG UID=1000
-ARG GID=1000
-ARG USERNAME=app
-RUN usermod -u $UID $USERNAME && \
-    groupmod -g $GID $USERNAME && \
-    chown -R $UID:$GID /app /home/app
-USER app
-
 # Copy in the application code
 COPY --chown=app . .
 
@@ -37,8 +15,8 @@ RUN tna-build
 
 # Copy in the static assets from TNA Frontend
 RUN mkdir /app/app/static/assets; \
-    cp -r /app/node_modules/@nationalarchives/frontend/nationalarchives/assets/* /app/app/static/assets; \
-    poetry run python /app/manage.py collectstatic --no-input --clear
+	cp -r /app/node_modules/@nationalarchives/frontend/nationalarchives/assets/* /app/app/static/assets; \
+	poetry run python /app/manage.py collectstatic --no-input --clear
 
 # Delete source files, tests and docs
 RUN rm -fR /app/src /app/test /app/docs

--- a/README.md
+++ b/README.md
@@ -10,16 +10,6 @@ See [Technical Guide](/docs/technical-guide.md) for more technical information.
 
 ## Installation & Usage
 
-### Linux/Docker Engine Users
-
-If you're using Linux with Docker Engine, export your user ID and group ID first to avoid permission issues:
-
-```sh
-# Export your user/group IDs for Docker to use
-export UID=$(id -u)
-export GID=$(id -g)
-```
-
 ### Starting the Application
 
 Use docker compose to run the server:
@@ -120,40 +110,3 @@ In addition to the [base Docker image variables](https://github.com/nationalarch
 | `CSP_FRAME_SRC`          | A comma separated list of CSP rules for `frame-src`            | `'self'`                                                  |
 | `GA4_ID`                 | The Google Analytics 4 ID                                      | _none_                                                    |
 
-## Resolving Docker Build Permissions Issues
-
-If you encounter file permission errors (for example when installing node modules or mounting volumes) during Docker builds, especially on Linux, this project supports setting the UID/GID for the `app` user in the container to match your host system.
-
-### Why?
-
-Docker Engine handles file permissions differently to Docker Desktop and other tools. When mounting your project directory as a volume, files created by the container may be owned by a different user than your host, causing permission issues. Setting the UID/GID ensures files are owned correctly.
-
-### How to Use
-
-#### Docker Engine Users
-
-If you're using Linux with Docker Engine, export your user ID and group ID before building:
-
-```sh
-# Export your UID/GID as environment variables
-export UID=$(id -u)
-export GID=$(id -g)
-
-# Then run docker compose as usual
-docker compose up --build
-```
-
-#### Docker Desktop/OrbStack Users
-
-You usually do not need to set these variables. Simply run:
-
-```sh
-docker compose up --build
-```
-
-The default UID/GID values work for most Mac/Windows setups.
-
-### Troubleshooting
-
-- If you see permission errors (e.g., with `node_modules` or mounted files), check your UID/GID and rebuild as above.
-- For more details, see the relevant section in the `Dockerfile` and `docker-compose.override.yaml` files.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,8 +1,0 @@
-services:
-  app:
-    build:
-      args:
-        # Pass host user's UID/GID to avoid permission issues (mainly for Linux/Docker Engine)
-        # These will use the environment variables if set, or default to 1000
-        UID: ${UID:-1000}
-        GID: ${GID:-1000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       args:
-        IMAGE: ghcr.io/nationalarchives/tna-python-django
+        IMAGE: ghcr.io/nationalarchives/tna-python-django-root
         IMAGE_TAG: preview
     environment:
       - RUNTIME=develop


### PR DESCRIPTION
#### Description of the change

This will return the dockerfile to the state before #26 , to preserve the existing AWS build process. 

This should also address the issue of the broken local build on Linux. 



#### Dev checklist

- [x] PR addresses all ACs
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Added unit tests if necessary
- [x] Updated documentation if necessary
- [x] Self code review
- [x] Requested code review

#### Manual testing steps, if applicable

- Build and run the images locally on: 
  - Linux
  - MacOS



