### PR TITLE
Fix Feedback form count inaccuracy

### DIFF
--- a/app/editor_ui/views.py
+++ b/app/editor_ui/views.py
@@ -74,10 +74,12 @@ class ProjectDetailView(SuperuserRequiredMixin, LoginRequiredMixin, DetailView):
                 forms_count=Count(
                     "feedback_forms",
                     filter=Q(feedback_forms__disabled_at=None),
+                    distinct=True,
                 ),
                 responses_count=Count(
                     "feedback_forms__responses",
                     filter=Q(feedback_forms__disabled_at=None),
+                    distinct=True,
                 ),
             )
         )


### PR DESCRIPTION
Fix inflated counts of Feedback forms ~and Prompts~ on the project detail page.