### PR TITLE
feat: add breadcrumbs to pages in editor ui via TNA breadcrumbs component

### DIFF
--- a/app/editor_ui/mixins.py
+++ b/app/editor_ui/mixins.py
@@ -155,6 +155,7 @@ class BreadCrumbsMixin:
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
         context["breadcrumbs"] = self._breadcrumb_calculator()
+        return context
 
     def _breadcrumb_calculator(self):
         parts = self.request.path.split("/")
@@ -174,10 +175,12 @@ class BreadCrumbsMixin:
         try:
             resolved = resolve(url)
 
-            target = resolved.func.view_class
-            if issubclass(target, BreadCrumbsMixin):
-                return {"url": url, "slug": target.breadcrumb}
-            else:
-                return None
+            # Check if it's a class-based view
+            if hasattr(resolved.func, 'view_class'):
+                target = resolved.func.view_class
+                if issubclass(target, BreadCrumbsMixin):
+                    return {"href": url, "text": target.breadcrumb}
+            
+            return None
         except Resolver404:
             return None

--- a/app/editor_ui/mixins.py
+++ b/app/editor_ui/mixins.py
@@ -1,7 +1,7 @@
-from django.urls import Resolver404, resolve
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.shortcuts import get_object_or_404
+from django.urls import Resolver404, resolve
 from django.views.generic import DeleteView, DetailView, UpdateView
 
 from app.projects.models import Project, ProjectMembership

--- a/app/editor_ui/mixins.py
+++ b/app/editor_ui/mixins.py
@@ -155,7 +155,13 @@ class BreadCrumbsMixin:
     if the BreadCrumbsMixin is to work.
     """
 
-    breadcrumb = "Error"
+    def __init__(self) -> None:
+        if not hasattr(self, "breadcrumb"):
+            raise ImproperlyConfigured(
+                f"{self.__class__.__name__} requires 'breadcrumbs' to be set, as it's using the BreadCrumbsMixin."
+            )
+
+        super().__init__()
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)

--- a/app/editor_ui/urls.py
+++ b/app/editor_ui/urls.py
@@ -36,22 +36,22 @@ urlpatterns = [
         name="project_detail",
     ),
     path(
-        "projects/<uuid:project_uuid>/members",
+        "projects/<uuid:project_uuid>/members/",
         ProjectMembershipListView.as_view(),
         name="project__memberships",
     ),
     path(
-        "projects/<uuid:project_uuid>/members/add",
+        "projects/<uuid:project_uuid>/members/add/",
         ProjectMembershipCreateView.as_view(),
         name="project__memberships_add",
     ),
     path(
-        "projects/<uuid:project_uuid>/members/<uuid:membership_uuid>/edit",
+        "projects/<uuid:project_uuid>/members/<uuid:membership_uuid>/edit/",
         ProjectMembershipUpdateView.as_view(),
         name="project__memberships_edit",
     ),
     path(
-        "projects/<uuid:project_uuid>/members/<uuid:membership_uuid>/delete",
+        "projects/<uuid:project_uuid>/members/<uuid:membership_uuid>/delete/",
         ProjectMembershipDeleteView.as_view(),
         name="project__memberships_delete",
     ),

--- a/app/editor_ui/urls.py
+++ b/app/editor_ui/urls.py
@@ -71,7 +71,7 @@ urlpatterns = [
         name="project__feedback_form_detail",
     ),
     path(
-        "projects/<uuid:project_uuid>/feedback-forms/<uuid:feedback_form_uuid>/path-pattern/create",
+        "projects/<uuid:project_uuid>/feedback-forms/<uuid:feedback_form_uuid>/path-pattern/create/",
         PathPatternCreateView.as_view(),
         name="project__feedback_form__path_pattern_create",
     ),
@@ -86,7 +86,7 @@ urlpatterns = [
         name="project__feedback_form__prompt_detail",
     ),
     path(
-        "projects/<uuid:project_uuid>/feedback-forms/<uuid:feedback_form_uuid>/prompts/<uuid:prompt_uuid>/ranged-prompt-options/create",
+        "projects/<uuid:project_uuid>/feedback-forms/<uuid:feedback_form_uuid>/prompts/<uuid:prompt_uuid>/ranged-prompt-options/create/",
         RangedPromptOptionsCreateView.as_view(),
         name="project__feedback_form__prompt__ranged_prompt_options_create",
     ),

--- a/app/editor_ui/views/feedback_form_views.py
+++ b/app/editor_ui/views/feedback_form_views.py
@@ -12,6 +12,7 @@ from app.editor_ui.forms import (
     FeedbackFormForm,
 )
 from app.editor_ui.mixins import (
+    BreadCrumbsMixin,
     CreatedByUserMixin,
     ProjectMembershipRequiredMixin,
 )
@@ -27,6 +28,7 @@ class FeedbackFormCreateView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
     CreatedByUserMixin,
+    BreadCrumbsMixin,
     BaseCreateView,
 ):
     """
@@ -48,6 +50,8 @@ class FeedbackFormCreateView(
     project_roles_required = ["editor", "owner"]
     parent_model = Project
     parent_lookup_kwarg = "project_uuid"
+
+    breadcrumb = "Create a Feedback Form"
 
     def form_valid(self, form):
         """
@@ -76,6 +80,7 @@ class FeedbackFormCreateView(
 class FeedbackFormListView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
+    BreadCrumbsMixin,
     ListView,
 ):
     """
@@ -95,6 +100,8 @@ class FeedbackFormListView(
     project_roles_required = ["editor", "owner"]
     parent_model = Project
     parent_lookup_kwarg = "project_uuid"
+
+    breadcrumb = "Feedback Forms"
 
     def get_queryset(self):
         qs = (
@@ -122,6 +129,7 @@ class FeedbackFormListView(
 class FeedbackFormDetailView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
+    BreadCrumbsMixin,
     DetailView,
 ):
     """
@@ -139,6 +147,8 @@ class FeedbackFormDetailView(
     slug_url_kwarg = "feedback_form_uuid"
     context_object_name = "feedback_form"
     project_roles_required = ["editor", "owner"]
+
+    breadcrumb = "Feedback Form Details"
 
     def get_queryset(self):
         return (

--- a/app/editor_ui/views/membership_views.py
+++ b/app/editor_ui/views/membership_views.py
@@ -13,6 +13,7 @@ from app.editor_ui.forms import (
     ProjectMembershipUpdateForm,
 )
 from app.editor_ui.mixins import (
+    BreadCrumbsMixin,
     ProjectMembershipRequiredMixin,
     ProjectOwnerMembershipMixin,
 )
@@ -24,6 +25,7 @@ from app.projects.models import Project, ProjectMembership
 class ProjectMembershipListView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
+    BreadCrumbsMixin,
     ListView,
 ):
     model = ProjectMembership
@@ -35,6 +37,8 @@ class ProjectMembershipListView(
     project_roles_required = ["editor", "owner"]
     parent_model = Project
     parent_lookup_kwarg = "project_uuid"
+
+    breadcrumb = "Project Members"
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -83,6 +87,7 @@ class ProjectMembershipCreateView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
     ProjectOwnerMembershipMixin,
+    BreadCrumbsMixin,
     BaseCreateView,
 ):
     form_class = ProjectMembershipCreateForm
@@ -92,6 +97,8 @@ class ProjectMembershipCreateView(
     project_roles_required = ["owner"]
     parent_model = Project
     parent_lookup_kwarg = "project_uuid"
+
+    breadcrumb = "Add Members to Project"
 
     def form_valid(self, form):
         project_uuid = self.kwargs.get("project_uuid")
@@ -138,6 +145,7 @@ class ProjectMembershipUpdateView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
     ProjectOwnerMembershipMixin,
+    BreadCrumbsMixin,
     UpdateView,
 ):
     form_class = ProjectMembershipUpdateForm
@@ -150,6 +158,8 @@ class ProjectMembershipUpdateView(
     project_roles_required = ["owner"]
     parent_model = Project
     parent_lookup_kwarg = "project_uuid"
+
+    breadcrumb = "Update Project Membership"
 
     def get_queryset(self):
         # Limit the queryset to memberships of the specified project
@@ -174,6 +184,7 @@ class ProjectMembershipUpdateView(
 class ProjectMembershipDeleteView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
+    BreadCrumbsMixin,
     DeleteView,
 ):
     model = ProjectMembership
@@ -186,6 +197,8 @@ class ProjectMembershipDeleteView(
     project_roles_required = ["owner"]
     parent_model = Project
     parent_lookup_kwarg = "project_uuid"
+
+    breadcrumb = "Remove Project Membership"
 
     def get_queryset(self):
         project_uuid = self.kwargs.get("project_uuid")

--- a/app/editor_ui/views/path_pattern_views.py
+++ b/app/editor_ui/views/path_pattern_views.py
@@ -5,11 +5,12 @@ from app.editor_ui.forms import (
     PathPatternForm,
 )
 from app.editor_ui.mixins import (
+    BreadCrumbsMixin,
     CreatedByUserMixin,
     ProjectMembershipRequiredMixin,
 )
 from app.editor_ui.views.base_views import BaseCreateView
-from app.feedback_forms.models import FeedbackForm, PathPattern
+from app.feedback_forms.models import FeedbackForm
 from app.projects.models import Project
 
 
@@ -17,6 +18,7 @@ class PathPatternCreateView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
     CreatedByUserMixin,
+    BreadCrumbsMixin,
     BaseCreateView,
 ):
     form_class = PathPatternForm
@@ -26,6 +28,8 @@ class PathPatternCreateView(
     project_roles_required = ["editor", "owner"]
     parent_model = FeedbackForm
     parent_lookup_kwarg = "feedback_form_uuid"
+
+    breadcrumb = "Create a Path Pattern"
 
     def form_valid(self, form):
         instance = form.save(commit=False)

--- a/app/editor_ui/views/project_views.py
+++ b/app/editor_ui/views/project_views.py
@@ -15,6 +15,7 @@ from app.editor_ui.forms import (
     ProjectForm,
 )
 from app.editor_ui.mixins import (
+    BreadCrumbsMixin,
     CreatedByUserMixin,
     ProjectMembershipRequiredMixin,
     ProjectOwnerMembershipMixin,
@@ -28,11 +29,13 @@ class ProjectCreateView(
     PermissionRequiredMixin,
     CreatedByUserMixin,
     ProjectOwnerMembershipMixin,
+    BreadCrumbsMixin,
     BaseCreateView,
 ):
     form_class = ProjectForm
     object_name = "Project"
     permission_required = ["projects.add_project"]
+    breadcrumb = "Create a Project"
 
     def get_success_url(self):
         return reverse(
@@ -43,12 +46,14 @@ class ProjectCreateView(
 
 class ProjectListView(
     LoginRequiredMixin,
+    BreadCrumbsMixin,
     ListView,
 ):
     model = Project
     template_name = "editor_ui/projects/project_list.html"
     context_object_name = "projects"
     project_roles_required = ["editor", "owner"]
+    breadcrumb = "Projects"
 
     def get_queryset(self):
         """

--- a/app/editor_ui/views/project_views.py
+++ b/app/editor_ui/views/project_views.py
@@ -53,6 +53,7 @@ class ProjectListView(
     template_name = "editor_ui/projects/project_list.html"
     context_object_name = "projects"
     project_roles_required = ["editor", "owner"]
+
     breadcrumb = "Projects"
 
     def get_queryset(self):
@@ -100,6 +101,7 @@ class ProjectListView(
 class ProjectDetailView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
+    BreadCrumbsMixin,
     DetailView,
 ):
     model = Project
@@ -109,6 +111,8 @@ class ProjectDetailView(
 
     # ProjectMembershipRequiredMixin mixin attributes
     project_roles_required = ["editor", "owner"]
+
+    breadcrumb = "Project Details"
 
     def get_queryset(self):
         UserModel = get_user_model()

--- a/app/editor_ui/views/prompt_views.py
+++ b/app/editor_ui/views/prompt_views.py
@@ -17,6 +17,7 @@ from app.editor_ui.forms import (
     RangedPromptOptionsForm,
 )
 from app.editor_ui.mixins import (
+    BreadCrumbsMixin,
     CreatedByUserMixin,
     ProjectMembershipRequiredMixin,
 )
@@ -33,6 +34,7 @@ class PromptCreateView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
     CreatedByUserMixin,
+    BreadCrumbsMixin,
     BaseCreateView,
 ):
     """
@@ -53,6 +55,8 @@ class PromptCreateView(
     project_roles_required = ["editor", "owner"]
     parent_model = FeedbackForm
     parent_lookup_kwarg = "feedback_form_uuid"
+
+    breadcrumb = "Create a Prompt"
 
     MAX_ACTIVE_PROMPTS = 3
 
@@ -137,6 +141,7 @@ class PromptCreateView(
 class PromptDetailView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
+    BreadCrumbsMixin,
     DetailView,
 ):
     """
@@ -153,6 +158,8 @@ class PromptDetailView(
     slug_url_kwarg = "prompt_uuid"
     context_object_name = "prompt"
     project_roles_required = ["editor", "owner"]
+
+    breadcrumb = "Prompt Details"
 
     def get_queryset(self):
         prompt_uuid = self.kwargs.get("prompt_uuid")
@@ -202,6 +209,7 @@ class PromptDetailView(
 class RangedPromptOptionsCreateView(
     LoginRequiredMixin,
     ProjectMembershipRequiredMixin,
+    BreadCrumbsMixin,
     BaseCreateView,
 ):
     form_class = RangedPromptOptionsForm
@@ -211,6 +219,8 @@ class RangedPromptOptionsCreateView(
     project_roles_required = ["editor", "owner"]
     parent_model = RangedPrompt
     parent_lookup_kwarg = "prompt_uuid"
+
+    breadcrumb = "Create a Ranged Prompt Option"
 
     def get_success_url(self):
         prompt_uuid = self.kwargs.get("prompt_uuid")


### PR DESCRIPTION
#### Description of the change

Add a Breadcrumbs Mixin that will: 
- add breadcrumbs to views
- update context such that the existing TNA breadcrumbs component can make use of it


Besides this, I've also: 
- Standardize all urls in the editor_ui to have a `/` suffix
- Added breadcrumbs to all existing views

Inspired from: https://www.youtube.com/watch?v=6bxSjxp2ZRY

#### Tickets

- [WE-84](https://national-archives.atlassian.net/browse/WE-84)

#### Dev checklist

- [ ] PR addresses all ACs
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Added unit tests if necessary
- [ ] Updated documentation if necessary
- [ ] Self code review
- [ ] Requested code review

#### Manual testing steps, if applicable

Navigate to all the possible page, and ensure each page has an accurate breadcrumbs trail that will allow you to go back to any previous page in the hierarchy as follows: 

- Projects
- Projects / Feedback Forms
- Projects / Feedback Forms / Path Patterns
- Projects / Feedback Forms / Prompts
- Projects / Feedback Forms / Prompts / Prompt Options



#### Screenshots/GIFs

<img width="5816" height="3170" alt="image" src="https://github.com/user-attachments/assets/a8c91d8b-3eac-403e-9688-cb8097093a7c" />






[WE-84]: https://national-archives.atlassian.net/browse/WE-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ